### PR TITLE
hotfix - V2 welcome API is missing ETH in token list - avoiding error

### DIFF
--- a/src/services/api/bancorApi/bancorApiV2.ts
+++ b/src/services/api/bancorApi/bancorApiV2.ts
@@ -19,7 +19,7 @@ export abstract class BancorV2Api {
       dlt_id: wethToken,
       symbol: 'WETH',
     };
-    data.tokens.push(wethTkn);
+    if (weth) data.tokens.push(wethTkn);
     return {
       ...data,
       pools: data.pools.map((pool) => ({


### PR DESCRIPTION
we are adding WETH token in the frontend and base it on the ETH rates as they arrive from the V2 welcome API - but it doesn't return info for ETH. So now I added a check just to avoid this error as it prevents loading the Vote page properly.